### PR TITLE
Bump `evm-lite-lib` to 0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "evm-lite-lib": "0.1.14",
+    "evm-lite-lib": "0.1.22",
     "react": "^16.6.1",
     "react-alert": "^4.0.4",
     "react-alert-template-basic": "^1.0.0",


### PR DESCRIPTION
In the 0.1.14 version, the dependency of `ethereum/web3.js` has set to `github:ethereum/web3.js`,
but now, it has updated to v.1.0, this change will cause some files can't import the needed file,
so we need to upgrade the `evm-lite-lib`  to avoid errors.